### PR TITLE
renovate.jsonからpnpmを削除

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,12 +10,13 @@
   "additionalBranchPrefix": "{{newVersion}}-",
   "prHourlyLimit": 0,
   "prConcurrentLimit": 0,
-  "enabledManagers": ["github-actions"],
-  "pnpm": {
+  "enabledManagers": ["npm", "github-actions"],
+  "npm": {
     "extends": [
       ":noUnscheduledUpdates",
       "npm:unpublishSafe"
     ],
+    "postUpdateOptions": ["pnpmDedupe"],
     "rangeStrategy": "bump",
     "semanticCommitType": "chore",
     "separateMinorPatch": true,


### PR DESCRIPTION
## やりたいこと

renovate.jsonからpnpmを削除

## やったこと

- renovate.jsonからpnpmを削除
  - `npm` に変更し、`"postUpdateOptions": ["pnpmDedupe"]` を追加

## やらなかったこと

🍐

## 確認方法

fmfm でおｋ

## マージ後にやること

🍐
